### PR TITLE
Add Button Maps For Raspberry Pi GPIO Controllers

### DIFF
--- a/linux/GPIO_Controller_1_9b_2a.xml
+++ b/linux/GPIO_Controller_1_9b_2a.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="GPIO Controller 1" provider="linux" buttoncount="9" axiscount="2">
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+1" />
+            <feature name="guide" button="8" />
+            <feature name="left" axis="-0" />
+            <feature name="lefttrigger" button="4" />
+            <feature name="right" axis="+0" />
+            <feature name="righttrigger" button="5" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+        <controller id="game.controller.gba">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+0" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="6" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+        </controller>
+        <controller id="game.controller.genesis">
+            <feature name="a" button="3" />
+            <feature name="b" button="1" />
+            <feature name="c" button="0" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="mode" button="6" />
+            <feature name="right" axis="+0" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="4" />
+            <feature name="y" button="2" />
+            <feature name="z" button="5" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="right" axis="+0" />
+            <feature name="select" button="6" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+        </controller>
+        <controller id="game.controller.snes">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+0" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="6" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/linux/GPIO_Controller_2_9b_2a.xml
+++ b/linux/GPIO_Controller_2_9b_2a.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="GPIO Controller 2" provider="linux" buttoncount="9" axiscount="2">
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+1" />
+            <feature name="guide" button="8" />
+            <feature name="left" axis="-0" />
+            <feature name="lefttrigger" button="4" />
+            <feature name="right" axis="+0" />
+            <feature name="righttrigger" button="5" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+        <controller id="game.controller.gba">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+0" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="6" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+        </controller>
+        <controller id="game.controller.genesis">
+            <feature name="a" button="3" />
+            <feature name="b" button="1" />
+            <feature name="c" button="0" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="mode" button="6" />
+            <feature name="right" axis="+0" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="4" />
+            <feature name="y" button="2" />
+            <feature name="z" button="5" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="right" axis="+0" />
+            <feature name="select" button="6" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+        </controller>
+        <controller id="game.controller.snes">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+0" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="6" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
Keymaps for GPIO controllers using module from https://github.com/recalbox/mk_arcade_joystick_rpi
I used the hotkey branch giving an extra button (8) which I mapped to guide.

I only mapped buttons for systems that the controllers have enough buttons for.